### PR TITLE
added field project_infra to import_export

### DIFF
--- a/classifai-core/src/main/java/ai/classifai/action/parser/PortfolioParser.java
+++ b/classifai-core/src/main/java/ai/classifai/action/parser/PortfolioParser.java
@@ -21,6 +21,8 @@ import ai.classifai.database.versioning.Version;
 import ai.classifai.loader.LoaderStatus;
 import ai.classifai.loader.ProjectLoader;
 import ai.classifai.util.ParamConfig;
+import ai.classifai.util.project.ProjectInfra;
+import ai.classifai.util.project.ProjectInfraHandler;
 import ai.classifai.util.type.AnnotationHandler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.sqlclient.Row;
@@ -59,11 +61,12 @@ public class PortfolioParser
         jsonObject.put(ParamConfig.getIsNewParam(), row.getBoolean(4));                                     //is_new
         jsonObject.put(ParamConfig.getIsStarredParam(), row.getBoolean(5));                                 //is_starred
 
-        jsonObject.put(ParamConfig.getCurrentVersionParam(), row.getString(6));                             //current version
-        jsonObject.put(ParamConfig.getProjectVersionParam(), row.getString(7));                             //project version
-        jsonObject.put(ParamConfig.getUuidVersionListParam(), row.getString(8));                            //uuid_version_list
+        jsonObject.put(ParamConfig.getProjectInfraParam(), row.getString(6).toLowerCase());                 //project_infra
+        jsonObject.put(ParamConfig.getCurrentVersionParam(), row.getString(7));                             //current version
+        jsonObject.put(ParamConfig.getProjectVersionParam(), row.getString(8));                             //project version
+        jsonObject.put(ParamConfig.getUuidVersionListParam(), row.getString(9));                            //uuid_version_list
 
-        jsonObject.put(ParamConfig.getLabelVersionListParam(), row.getString(9));                           //label_version_list
+        jsonObject.put(ParamConfig.getLabelVersionListParam(), row.getString(10));                          //label_version_list
     }
 
     public static ProjectLoader parseIn(@NonNull JsonObject jsonObject)
@@ -83,6 +86,8 @@ public class PortfolioParser
         Map labelDict = ActionOps.getKeyWithArray(jsonObject.getString(ParamConfig.getLabelVersionListParam()));
         project.setLabelListDict(labelDict);                                                                        //label_version_list
 
+
+        ProjectInfra projectInfra = ProjectInfraHandler.getInfra(jsonObject.getString(ParamConfig.getProjectInfraParam()));
         return ProjectLoader.builder()
                                 .projectId(jsonObject.getString(ParamConfig.getProjectIdParam()))               //project_id
                                 .projectName(jsonObject.getString(ParamConfig.getProjectNameParam()))           //project_name
@@ -91,6 +96,8 @@ public class PortfolioParser
                                 .projectPath(jsonObject.getString(ParamConfig.getProjectPathParam()))           //project_path
                                 .isProjectNew(jsonObject.getBoolean(ParamConfig.getIsNewParam()))               //is_new
                                 .isProjectStarred(jsonObject.getBoolean(ParamConfig.getIsStarredParam()))       //is_starred
+
+                                .projectInfra(projectInfra)                                                     //project_infra
 
                                 .loaderStatus(LoaderStatus.DID_NOT_INITIATED)
 


### PR DESCRIPTION
# Description

@devenyantis 

making changes to import/export which i missed out when adding
a field of **project_infra** to check if project is on-premise / cloud. 

<img width="1145" alt="Screenshot 2021-03-23 at 9 53 00 PM" src="https://user-images.githubusercontent.com/33477318/112158107-d2e60a00-8c22-11eb-81bd-457f02ae0eee.png">


to give a little more context, this is necessary in the sense that if the project is based on cloud storage, 
then connection to internet will be confirmed prior to loading project 

doing a PR to let you aware what are the changes.

if there's no concern, do merge and delete this branch.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tested on?

- [ ] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [x] Mac  
- [ ] Others  (State here -> xxx )  
