### PR TITLE
Fix jbdcpool null pointer error during start up if project exists in database

### DIFF
--- a/classifai-core/src/main/java/ai/classifai/MainVerticle.java
+++ b/classifai-core/src/main/java/ai/classifai/MainVerticle.java
@@ -95,6 +95,7 @@ public class MainVerticle extends AbstractVerticle
 
             if (ar.succeeded())
             {
+                portfolioVerticle.configProjectLoaderFromDb();
                 portfolioVerticle.buildProjectFromCLI();
 
                 LogoLauncher.print();

--- a/classifai-core/src/main/java/ai/classifai/database/portfolio/PortfolioVerticle.java
+++ b/classifai-core/src/main/java/ai/classifai/database/portfolio/PortfolioVerticle.java
@@ -451,22 +451,27 @@ public class PortfolioVerticle extends AbstractVerticle implements VerticleServi
                                 Map labelDict = ActionOps.getKeyWithArray(row.getString(10));
                                 project.setLabelListDict(labelDict);                                                    //label_project_version
 
-                                ProjectLoader loader = ProjectLoader.builder()
-                                    .projectId(row.getString(0))                                                   //project_id
-                                    .projectName(row.getString(1))                                                 //project_name
-                                    .annotationType(row.getInteger(2))                                             //annotation_type
-                                    .projectPath(row.getString(3))                                                 //project_path
-                                    .loaderStatus(LoaderStatus.DID_NOT_INITIATED)
-                                    .isProjectNew(row.getBoolean(4))                                               //is_new
-                                    .isProjectStarred(row.getBoolean(5))                                           //is_starred
-                                    .projectInfra(ProjectInfraHandler.getInfra(row.getString(6)))                  //project_infra
-                                    .projectVersion(project)                                                           //project_version
-                                    .build();
+                                vertx.executeBlocking(future -> {
+                                    ProjectLoader loader = ProjectLoader.builder()
+                                            .projectId(row.getString(0))                                                   //project_id
+                                            .projectName(row.getString(1))                                                 //project_name
+                                            .annotationType(row.getInteger(2))                                             //annotation_type
+                                            .projectPath(row.getString(3))                                                 //project_path
+                                            .loaderStatus(LoaderStatus.DID_NOT_INITIATED)
+                                            .isProjectNew(row.getBoolean(4))                                               //is_new
+                                            .isProjectStarred(row.getBoolean(5))                                           //is_starred
+                                            .projectInfra(ProjectInfraHandler.getInfra(row.getString(6)))                  //project_infra
+                                            .projectVersion(project)                                                           //project_version
+                                            .build();
 
-                                //load each data points
-                                AnnotationVerticle.configProjectLoaderFromDb(loader);
+                                    //load each data points
+                                    AnnotationVerticle.configProjectLoaderFromDb(loader);
 
-                                ProjectHandler.loadProjectLoader(loader);
+                                    ProjectHandler.loadProjectLoader(loader);
+
+                                    future.complete();
+                                });
+
                             }
                         }
                     }

--- a/classifai-core/src/main/java/ai/classifai/database/portfolio/PortfolioVerticle.java
+++ b/classifai-core/src/main/java/ai/classifai/database/portfolio/PortfolioVerticle.java
@@ -452,23 +452,21 @@ public class PortfolioVerticle extends AbstractVerticle implements VerticleServi
                                 project.setLabelListDict(labelDict);                                                    //label_project_version
 
                                 ProjectLoader loader = ProjectLoader.builder()
-                                        .projectId(row.getString(0))                                                   //project_id
-                                        .projectName(row.getString(1))                                                 //project_name
-                                        .annotationType(row.getInteger(2))                                             //annotation_type
-                                        .projectPath(row.getString(3))                                                 //project_path
-                                        .loaderStatus(LoaderStatus.DID_NOT_INITIATED)
-                                        .isProjectNew(row.getBoolean(4))                                               //is_new
-                                        .isProjectStarred(row.getBoolean(5))                                           //is_starred
-                                        .projectInfra(ProjectInfraHandler.getInfra(row.getString(6)))                  //project_infra
-                                        .projectVersion(project)                                                           //project_version
-                                        .build();
+                                    .projectId(row.getString(0))                                                   //project_id
+                                    .projectName(row.getString(1))                                                 //project_name
+                                    .annotationType(row.getInteger(2))                                             //annotation_type
+                                    .projectPath(row.getString(3))                                                 //project_path
+                                    .loaderStatus(LoaderStatus.DID_NOT_INITIATED)
+                                    .isProjectNew(row.getBoolean(4))                                               //is_new
+                                    .isProjectStarred(row.getBoolean(5))                                           //is_starred
+                                    .projectInfra(ProjectInfraHandler.getInfra(row.getString(6)))                  //project_infra
+                                    .projectVersion(project)                                                           //project_version
+                                    .build();
 
                                 //load each data points
                                 AnnotationVerticle.configProjectLoaderFromDb(loader);
 
                                 ProjectHandler.loadProjectLoader(loader);
-
-
                             }
                         }
                     }

--- a/classifai-core/src/main/java/ai/classifai/database/portfolio/PortfolioVerticle.java
+++ b/classifai-core/src/main/java/ai/classifai/database/portfolio/PortfolioVerticle.java
@@ -422,7 +422,7 @@ public class PortfolioVerticle extends AbstractVerticle implements VerticleServi
                 });
     }
 
-    private void configProjectLoaderFromDb()
+    public void configProjectLoaderFromDb()
     {
         portfolioDbPool.query(PortfolioDbQuery.getRetrieveAllProjects())
                 .execute()
@@ -451,26 +451,23 @@ public class PortfolioVerticle extends AbstractVerticle implements VerticleServi
                                 Map labelDict = ActionOps.getKeyWithArray(row.getString(10));
                                 project.setLabelListDict(labelDict);                                                    //label_project_version
 
-                                vertx.executeBlocking(future -> {
-                                    ProjectLoader loader = ProjectLoader.builder()
-                                            .projectId(row.getString(0))                                                   //project_id
-                                            .projectName(row.getString(1))                                                 //project_name
-                                            .annotationType(row.getInteger(2))                                             //annotation_type
-                                            .projectPath(row.getString(3))                                                 //project_path
-                                            .loaderStatus(LoaderStatus.DID_NOT_INITIATED)
-                                            .isProjectNew(row.getBoolean(4))                                               //is_new
-                                            .isProjectStarred(row.getBoolean(5))                                           //is_starred
-                                            .projectInfra(ProjectInfraHandler.getInfra(row.getString(6)))                  //project_infra
-                                            .projectVersion(project)                                                           //project_version
-                                            .build();
+                                ProjectLoader loader = ProjectLoader.builder()
+                                        .projectId(row.getString(0))                                                   //project_id
+                                        .projectName(row.getString(1))                                                 //project_name
+                                        .annotationType(row.getInteger(2))                                             //annotation_type
+                                        .projectPath(row.getString(3))                                                 //project_path
+                                        .loaderStatus(LoaderStatus.DID_NOT_INITIATED)
+                                        .isProjectNew(row.getBoolean(4))                                               //is_new
+                                        .isProjectStarred(row.getBoolean(5))                                           //is_starred
+                                        .projectInfra(ProjectInfraHandler.getInfra(row.getString(6)))                  //project_infra
+                                        .projectVersion(project)                                                           //project_version
+                                        .build();
 
-                                    //load each data points
-                                    AnnotationVerticle.configProjectLoaderFromDb(loader);
+                                //load each data points
+                                AnnotationVerticle.configProjectLoaderFromDb(loader);
 
-                                    ProjectHandler.loadProjectLoader(loader);
+                                ProjectHandler.loadProjectLoader(loader);
 
-                                    future.complete();
-                                });
 
                             }
                         }
@@ -703,8 +700,6 @@ public class PortfolioVerticle extends AbstractVerticle implements VerticleServi
                                 if (create.succeeded()) {
                                     //the consumer methods registers an event bus destination handler
                                     vertx.eventBus().consumer(PortfolioDbQuery.getQueue(), this::onMessage);
-
-                                    configProjectLoaderFromDb();
 
                                     promise.complete();
                                 }


### PR DESCRIPTION
# Description

During program starting up, jdbcPool sometimes might be null if there's existing project in database. (due to asynchronous behavior)

`Apr 03, 2021 11:34:13 AM ERROR io.vertx.core.impl.ContextImpl - Unhandled exception
java.lang.NullPointerException: null
	at ai.classifai.database.annotation.AnnotationVerticle.configProjectLoaderFromDb(AnnotationVerticle.java:286)
	at ai.classifai.database.portfolio.PortfolioVerticle.lambda$configProjectLoaderFromDb$9(PortfolioVerticle.java:467)`

Workaround could be done by changing the sequence of calling [configProjectLoaderFromDb](https://github.com/CertifaiAI/classifai/blob/f79fc23cd3db16448e261e01911fa429eb762a9f/classifai-core/src/main/java/ai/classifai/database/portfolio/PortfolioVerticle.java#L425) method: 
calling it after PortfolioVerticle is started  ->  calling it after all vericles are started


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tested on?

- [ ] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged