### PR TITLE
[WIP] Improve image validation time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ target/
 
 #log file
 classifai.log
+
+#distro folder
+classifai-distro

--- a/classifai-core/src/main/java/ai/classifai/util/data/ImageHandler.java
+++ b/classifai-core/src/main/java/ai/classifai/util/data/ImageHandler.java
@@ -30,6 +30,7 @@ import com.drew.imaging.ImageMetadataReader;
 import com.drew.imaging.jpeg.JpegMetadataReader;
 import com.drew.metadata.Directory;
 import com.drew.metadata.Metadata;
+import com.drew.metadata.MetadataException;
 import com.drew.metadata.bmp.BmpHeaderDirectory;
 import com.drew.metadata.exif.ExifIFD0Directory;
 import com.drew.metadata.jpeg.JpegDirectory;
@@ -376,7 +377,7 @@ public class ImageHandler {
         saveToDatabase(projectID, totalFilelist);
     }
 
-    private static int getWidth(Metadata metadata) throws NotSupportedImageTypeError
+    private static int getWidth(Metadata metadata) throws NotSupportedImageTypeError, MetadataException
     {
         int width;
 
@@ -400,7 +401,7 @@ public class ImageHandler {
         return Math.abs(width);
     }
 
-    private static int getHeight(Metadata metadata) throws NotSupportedImageTypeError
+    private static int getHeight(Metadata metadata) throws NotSupportedImageTypeError, MetadataException
     {
         int height;
 

--- a/classifai-core/src/main/java/ai/classifai/util/data/ImageHandler.java
+++ b/classifai-core/src/main/java/ai/classifai/util/data/ImageHandler.java
@@ -376,7 +376,7 @@ public class ImageHandler {
         saveToDatabase(projectID, totalFilelist);
     }
 
-    private static int getWidth(Metadata metadata) throws Exception
+    private static int getWidth(Metadata metadata) throws NotSupportedImageTypeError
     {
         int width;
 
@@ -394,13 +394,13 @@ public class ImageHandler {
         }
         else
         {
-            throw new Exception("File type not supported");
+            throw new NotSupportedImageTypeError("File type not supported");
         }
 
         return Math.abs(width);
     }
 
-    private static int getHeight(Metadata metadata) throws Exception
+    private static int getHeight(Metadata metadata) throws NotSupportedImageTypeError
     {
         int height;
 
@@ -418,9 +418,17 @@ public class ImageHandler {
         }
         else
         {
-            throw new Exception("File type not supported");
+            throw new NotSupportedImageTypeError("File type not supported");
         }
 
         return Math.abs(height);
+    }
+
+    static class NotSupportedImageTypeError extends Exception
+    {
+        public NotSupportedImageTypeError(String message)
+        {
+            super(message);
+        }
     }
 }


### PR DESCRIPTION
# Description
During image import, there's a validation process of import images.
Current method used is try to **read the image files**, finding the width and height...
https://github.com/CertifaiAI/classifai/blob/main/classifai-core/src/main/java/ai/classifai/util/data/ImageHandler.java#L250-L274

Method proposed to shorten the validation time is by **reading the metadata** of images instead of reading the whole image.

Amount of time reduce:
3500 images: 10 mins -> 20 secs 
this [folder](https://drive.google.com/file/d/1R5jaaqlCWr3StE0KH1hPsL79s0AW_vcg/view?usp=sharing) contains the tested images.
[fake images](https://drive.google.com/file/d/1F_OMJH__bHZUcRpptxytfnyzynGNaH-S/view?usp=sharing) are also provided to test on ability to filter invalid files.

## Type of change
performance improvement.

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tested on?

- [ ] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged