### PR TITLE
Add import status check api

### DIFF
--- a/classifai-core/src/main/java/ai/classifai/action/ProjectImport.java
+++ b/classifai-core/src/main/java/ai/classifai/action/ProjectImport.java
@@ -41,7 +41,7 @@ import static javax.swing.JOptionPane.showMessageDialog;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProjectImport
 {
-    public static void importProjectFile(@NonNull File jsonFile)
+    public static boolean importProjectFile(@NonNull File jsonFile)
     {
         try
         {
@@ -53,7 +53,7 @@ public class ProjectImport
 
             if(!checkToolVersion(inputJsonObject) || !checkJsonKeys(inputJsonObject))
             {
-                return;
+                return false;
             }
 
             PortfolioVerticle.loadProjectFromImportingConfigFile(inputJsonObject);
@@ -62,7 +62,10 @@ public class ProjectImport
         catch(Exception e)
         {
             log.info("Error in importing project. ", e);
+            return false;
         }
+
+        return true;
     }
 
     public static boolean checkJsonKeys(JsonObject inputJsonObject)

--- a/classifai-core/src/main/java/ai/classifai/router/EndpointRouter.java
+++ b/classifai-core/src/main/java/ai/classifai/router/EndpointRouter.java
@@ -137,6 +137,8 @@ public class EndpointRouter extends AbstractVerticle
 
         router.get("/v2/:annotation_type/projects/:project_name/filesysstatus").handler(v2::getFileSystemStatus);
 
+        router.get("/v2/:annotation_type/projects/importstatus").handler(v2::getImportStatus);
+
         //*******************************Cloud*******************************
 
         router.put("/v2/:annotation_type/wasabi/newproject/:project_name").handler(cloud::createWasabiCloudProject);

--- a/classifai-core/src/main/java/ai/classifai/router/V2Endpoint.java
+++ b/classifai-core/src/main/java/ai/classifai/router/V2Endpoint.java
@@ -270,10 +270,10 @@ public class V2Endpoint {
 
     /**
      * Get file system (file/folder) status for a specific project
-     * GET http://localhost:{port}/:annotation_type/projects/:project_name/filesysstatus
+     * GET http://localhost:{port}/v2/:annotation_type/projects/:project_name/filesysstatus
      *
      * Example:
-     * GET http://localhost:{port}/bndbox/projects/helloworld/filesysstatus
+     * GET http://localhost:{port}/v2/bndbox/projects/helloworld/filesysstatus
      *
      */
     public void getFileSystemStatus(RoutingContext context)
@@ -314,5 +314,23 @@ public class V2Endpoint {
         }
 
         HTTPResponseHandler.configureOK(context, res);
+    }
+
+    /**
+     * Get import project status
+     * GET http://localhost:{port}/v2/:annotation_type/projects/importstatus
+     *
+     * Example:
+     * GET http://localhost:{port}/v2/bndbox/projects/importstatus
+     *
+     */
+    public void getImportStatus(RoutingContext context)
+    {
+        util.checkIfDockerEnv(context);
+
+        FileSystemStatus currentStatus = ProjectImportSelector.getImportFileSystemStatus();
+
+        HTTPResponseHandler.configureOK(context,
+                new JsonObject().put(ReplyHandler.getMessageKey(), currentStatus.ordinal()));
     }
 }

--- a/classifai-core/src/main/java/ai/classifai/selector/project/ProjectFolderSelector.java
+++ b/classifai-core/src/main/java/ai/classifai/selector/project/ProjectFolderSelector.java
@@ -15,14 +15,12 @@
  */
 package ai.classifai.selector.project;
 
-import ai.classifai.data.type.image.ImageFileType;
 import ai.classifai.database.versioning.ProjectVersion;
 import ai.classifai.loader.LoaderStatus;
 import ai.classifai.loader.ProjectLoader;
 import ai.classifai.selector.filesystem.FileSystemStatus;
-import ai.classifai.ui.launcher.LogoLauncher;
+import ai.classifai.ui.SelectionWindow;
 import ai.classifai.ui.launcher.WelcomeLauncher;
-import ai.classifai.util.ParamConfig;
 import ai.classifai.util.collection.UuidGenerator;
 import ai.classifai.util.data.ImageHandler;
 import ai.classifai.util.project.ProjectHandler;
@@ -35,13 +33,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 
 import javax.swing.*;
-import javax.swing.filechooser.FileNameExtensionFilter;
 import java.awt.*;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.Objects;
+
 import static javax.swing.JOptionPane.showMessageDialog;
 
 /**
@@ -50,9 +48,7 @@ import static javax.swing.JOptionPane.showMessageDialog;
  * @author codenamewei
  */
 @Slf4j
-public class ProjectFolderSelector {
-
-    private static final FileNameExtensionFilter imgFilter = new FileNameExtensionFilter("Image Files", ImageFileType.getImageFileTypes());
+public class ProjectFolderSelector extends SelectionWindow {
 
     public void run(@NonNull String projectName, @NonNull AnnotationType annotationType)
     {
@@ -68,8 +64,8 @@ public class ProjectFolderSelector {
 
                     loader.setFileSystemStatus(FileSystemStatus.WINDOW_OPEN);
 
-                    JFrame frame = initiateFrame();
-                    JFileChooser chooser = initiateChooser();
+                    JFrame frame = initFrame();
+                    JFileChooser chooser = initChooser(JFileChooser.DIRECTORIES_ONLY);
 
                     //Important: prevent Welcome Console from popping out
                     WelcomeLauncher.setToBackground();
@@ -102,43 +98,6 @@ public class ProjectFolderSelector {
         {
             log.info("ProjectFolderSelector failed to open", e);
         }
-    }
-
-    private JFrame initiateFrame()
-    {
-        Point pt = MouseInfo.getPointerInfo().getLocation();
-        JFrame frame = new JFrame();
-
-        frame.setIconImage(LogoLauncher.getClassifaiIcon());
-        frame.setAlwaysOnTop(true);
-        frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-        frame.setLocation(pt);
-        frame.requestFocus();
-        frame.setVisible(false);
-
-        return frame;
-    }
-
-    private JFileChooser initiateChooser()
-    {
-        JFileChooser chooser = new JFileChooser() {
-            @Override
-            protected JDialog createDialog(Component parent)
-                    throws HeadlessException {
-                JDialog dialog = super.createDialog(parent);
-                dialog.setLocationByPlatform(true);
-                dialog.setAlwaysOnTop(true);
-                return dialog;
-            }
-        };
-
-        chooser.setCurrentDirectory(ParamConfig.getRootSearchPath());
-        chooser.setFileFilter(imgFilter);
-        chooser.setDialogTitle("Select Directory");
-        chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
-        chooser.setAcceptAllFileFilterUsed(false);
-
-        return chooser;
     }
 
     private void showAbortProjectPopup()

--- a/classifai-core/src/main/java/ai/classifai/selector/project/ProjectImportSelector.java
+++ b/classifai-core/src/main/java/ai/classifai/selector/project/ProjectImportSelector.java
@@ -17,14 +17,12 @@ package ai.classifai.selector.project;
 
 import ai.classifai.action.ActionConfig;
 import ai.classifai.action.ProjectImport;
-import ai.classifai.ui.launcher.LogoLauncher;
+import ai.classifai.ui.SelectionWindow;
 import ai.classifai.ui.launcher.WelcomeLauncher;
-import ai.classifai.util.ParamConfig;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FilenameUtils;
 
 import javax.swing.*;
-import javax.swing.filechooser.FileNameExtensionFilter;
 import java.awt.*;
 import java.io.File;
 import java.nio.file.Paths;
@@ -37,18 +35,7 @@ import static javax.swing.JOptionPane.showMessageDialog;
  * @author codenamewei
  */
 @Slf4j
-public class ProjectImportSelector
-{
-    private enum ImportSelectionWindowStatus
-    {
-        WINDOW_OPEN,
-        WINDOW_CLOSE
-    }
-    private ImportSelectionWindowStatus windowStatus = ImportSelectionWindowStatus.WINDOW_CLOSE;
-
-    private static final FileNameExtensionFilter imgfilter = new FileNameExtensionFilter(
-            "Json Files", "json");
-
+public class ProjectImportSelector extends SelectionWindow {
     public void run()
     {
         try
@@ -61,8 +48,8 @@ public class ProjectImportSelector
                     {
                         windowStatus = ImportSelectionWindowStatus.WINDOW_OPEN;
 
-                        JFrame frame = initiateFrame();
-                        JFileChooser chooser = initiateChooser();
+                        JFrame frame = initFrame();
+                        JFileChooser chooser = initChooser(JFileChooser.FILES_ONLY);
 
                         //Important: prevent Welcome Console from popping out
                         WelcomeLauncher.setToBackground();
@@ -104,44 +91,6 @@ public class ProjectImportSelector
         {
             log.info("ProjectHandler for File type failed to open", e);
         }
-    }
-
-    private JFrame initiateFrame()
-    {
-        Point pt = MouseInfo.getPointerInfo().getLocation();
-        JFrame frame = new JFrame();
-        frame.setIconImage(LogoLauncher.getClassifaiIcon());
-
-        frame.setAlwaysOnTop(true);
-        frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-        frame.setLocation(pt);
-        frame.requestFocus();
-        frame.setVisible(false);
-
-        return frame;
-    }
-
-    private JFileChooser initiateChooser()
-    {
-        JFileChooser chooser = new JFileChooser() {
-            @Override
-            protected JDialog createDialog(Component parent)
-                    throws HeadlessException {
-                JDialog dialog = super.createDialog(parent);
-                dialog.setLocationByPlatform(true);
-                dialog.setAlwaysOnTop(true);
-                return dialog;
-            }
-        };
-
-        chooser.setCurrentDirectory(ParamConfig.getRootSearchPath());
-        chooser.setFileFilter(imgfilter);
-        chooser.setDialogTitle("Select Files");
-        chooser.setMultiSelectionEnabled(false);
-        chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
-        chooser.setAcceptAllFileFilterUsed(false);
-
-        return chooser;
     }
 
     private void showAbortImportPopup()

--- a/classifai-core/src/main/java/ai/classifai/ui/SelectionWindow.java
+++ b/classifai-core/src/main/java/ai/classifai/ui/SelectionWindow.java
@@ -2,6 +2,8 @@ package ai.classifai.ui;
 
 import ai.classifai.ui.launcher.LogoLauncher;
 import ai.classifai.util.ParamConfig;
+import lombok.Getter;
+import lombok.Setter;
 
 import javax.swing.*;
 import javax.swing.filechooser.FileNameExtensionFilter;
@@ -14,6 +16,9 @@ public class SelectionWindow {
         WINDOW_OPEN,
         WINDOW_CLOSE
     }
+
+    // To make sure window open once only
+    @Getter @Setter
     public ImportSelectionWindowStatus windowStatus = ImportSelectionWindowStatus.WINDOW_CLOSE;
 
     private final FileNameExtensionFilter imgFilter = new FileNameExtensionFilter(

--- a/classifai-core/src/main/java/ai/classifai/ui/SelectionWindow.java
+++ b/classifai-core/src/main/java/ai/classifai/ui/SelectionWindow.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2021 CertifAI Sdn. Bhd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package ai.classifai.ui;
 
 import ai.classifai.ui.launcher.LogoLauncher;
@@ -9,6 +24,11 @@ import javax.swing.*;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import java.awt.*;
 
+/**
+ * For selection windows initialization and settings
+ *
+ * @author devenyantis
+ */
 public class SelectionWindow {
 
     public enum ImportSelectionWindowStatus

--- a/classifai-core/src/main/java/ai/classifai/ui/SelectionWindow.java
+++ b/classifai-core/src/main/java/ai/classifai/ui/SelectionWindow.java
@@ -1,0 +1,59 @@
+package ai.classifai.ui;
+
+import ai.classifai.ui.launcher.LogoLauncher;
+import ai.classifai.util.ParamConfig;
+
+import javax.swing.*;
+import javax.swing.filechooser.FileNameExtensionFilter;
+import java.awt.*;
+
+public class SelectionWindow {
+
+    public enum ImportSelectionWindowStatus
+    {
+        WINDOW_OPEN,
+        WINDOW_CLOSE
+    }
+    public ImportSelectionWindowStatus windowStatus = ImportSelectionWindowStatus.WINDOW_CLOSE;
+
+    private final FileNameExtensionFilter imgFilter = new FileNameExtensionFilter(
+            "Json Files", "json");
+
+    public JFrame initFrame()
+    {
+        Point pt = MouseInfo.getPointerInfo().getLocation();
+        JFrame frame = new JFrame();
+        frame.setIconImage(LogoLauncher.getClassifaiIcon());
+
+        frame.setAlwaysOnTop(true);
+        frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+        frame.setLocation(pt);
+        frame.requestFocus();
+        frame.setVisible(false);
+
+        return frame;
+    }
+
+    public JFileChooser initChooser(int mode)
+    {
+        JFileChooser chooser = new JFileChooser() {
+            @Override
+            protected JDialog createDialog(Component parent)
+                    throws HeadlessException {
+                JDialog dialog = super.createDialog(parent);
+                dialog.setLocationByPlatform(true);
+                dialog.setAlwaysOnTop(true);
+                return dialog;
+            }
+        };
+
+        chooser.setCurrentDirectory(ParamConfig.getRootSearchPath());
+        chooser.setFileFilter(imgFilter);
+        chooser.setDialogTitle("Select Files");
+        chooser.setMultiSelectionEnabled(false);
+        chooser.setFileSelectionMode(mode);
+        chooser.setAcceptAllFileFilterUsed(false);
+
+        return chooser;
+    }
+}


### PR DESCRIPTION
# Description

Frontend need import status api to show animation while importing config file.

New api.
`http://localhost:9999/v2/:annotation_type/projects/importstatus`

Function. 
- Return WINDOW_OPEN if selection windows is still open
- Return WINDOW_CLOSE_DATABASE_NOT_UPDATED if selection window is cancelled, closed without choosing any file or invalid json file
- Return WINDOW_CLOSE_DATABASE_UPDATED if file is chosen and database is updated

**All changes is confirmed by frontend.**

Other changes.

- Create an abstract class called SelectionWindow for ProjectImportSelector and ProjectImportSelector
- SelectionWindow is placed in `ai.classifai.ui`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tested on?

- [X] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged