### PR TITLE
Add cache busting header & improve image validation time when import

### DIFF
--- a/classifai-core/src/main/java/ai/classifai/action/ProjectExport.java
+++ b/classifai-core/src/main/java/ai/classifai/action/ProjectExport.java
@@ -107,7 +107,7 @@ public class ProjectExport
     private static void addToEntry(File filePath, ZipOutputStream out, File dir) throws IOException
     {
         String relativePath = filePath.toString().substring(dir.getAbsolutePath().length()+1);
-        String saveFileRelativePath = Paths.get(filePath.getParentFile().getName(), relativePath).toFile().toString();
+        String saveFileRelativePath = Paths.get(dir.getName(), relativePath).toFile().toString();
 
         ZipEntry entry = new ZipEntry(saveFileRelativePath);
         out.putNextEntry(entry);

--- a/classifai-core/src/main/java/ai/classifai/action/parser/PortfolioParser.java
+++ b/classifai-core/src/main/java/ai/classifai/action/parser/PortfolioParser.java
@@ -92,8 +92,6 @@ public class PortfolioParser
                                 .projectId(jsonObject.getString(ParamConfig.getProjectIdParam()))               //project_id
                                 .projectName(jsonObject.getString(ParamConfig.getProjectNameParam()))           //project_name
                                 .annotationType(annotationInt)                                                  //annotation_type
-                                //FIXME
-                                // wrong path given
                                 .projectPath(ActionConfig.getJsonFilePath())           //project_path
                                 .isProjectNew(jsonObject.getBoolean(ParamConfig.getIsNewParam()))               //is_new
                                 .isProjectStarred(jsonObject.getBoolean(ParamConfig.getIsStarredParam()))       //is_starred

--- a/classifai-core/src/main/java/ai/classifai/action/parser/PortfolioParser.java
+++ b/classifai-core/src/main/java/ai/classifai/action/parser/PortfolioParser.java
@@ -15,6 +15,7 @@
  */
 package ai.classifai.action.parser;
 
+import ai.classifai.action.ActionConfig;
 import ai.classifai.action.ActionOps;
 import ai.classifai.database.versioning.ProjectVersion;
 import ai.classifai.database.versioning.Version;
@@ -91,8 +92,9 @@ public class PortfolioParser
                                 .projectId(jsonObject.getString(ParamConfig.getProjectIdParam()))               //project_id
                                 .projectName(jsonObject.getString(ParamConfig.getProjectNameParam()))           //project_name
                                 .annotationType(annotationInt)                                                  //annotation_type
-
-                                .projectPath(jsonObject.getString(ParamConfig.getProjectPathParam()))           //project_path
+                                //FIXME
+                                // wrong path given
+                                .projectPath(ActionConfig.getJsonFilePath())           //project_path
                                 .isProjectNew(jsonObject.getBoolean(ParamConfig.getIsNewParam()))               //is_new
                                 .isProjectStarred(jsonObject.getBoolean(ParamConfig.getIsStarredParam()))       //is_starred
 

--- a/classifai-core/src/main/java/ai/classifai/action/parser/ProjectParser.java
+++ b/classifai-core/src/main/java/ai/classifai/action/parser/ProjectParser.java
@@ -90,7 +90,7 @@ public class ProjectParser
             String uuid = item.getKey();
 
             JsonObject jsonObject = (JsonObject) item.getValue();
-            //FIXME
+
             String subPath = String.join(File.separator,jsonObject.getString(ParamConfig.getImgPathParam()).split("(/|\\\\)"));
 
             File fullPath = Paths.get(loader.getProjectPath(), subPath).toFile();

--- a/classifai-core/src/main/java/ai/classifai/action/parser/ProjectParser.java
+++ b/classifai-core/src/main/java/ai/classifai/action/parser/ProjectParser.java
@@ -55,7 +55,7 @@ public class ProjectParser
         {
             Row row = rowIterator.next();
 
-            String imgPath = StringHandler.removeSlashes(row.getString(1));
+            String imgPath = StringHandler.removeFirstSlashes(row.getString(1));
 
             String fullPath = Paths.get(projectPath, imgPath).toString();
 

--- a/classifai-core/src/main/java/ai/classifai/action/parser/ProjectParser.java
+++ b/classifai-core/src/main/java/ai/classifai/action/parser/ProjectParser.java
@@ -90,8 +90,8 @@ public class ProjectParser
             String uuid = item.getKey();
 
             JsonObject jsonObject = (JsonObject) item.getValue();
-
-            String subPath = jsonObject.getString(ParamConfig.getImgPathParam());
+            //FIXME
+            String subPath = String.join(File.separator,jsonObject.getString(ParamConfig.getImgPathParam()).split("(/|\\\\)"));
 
             File fullPath = Paths.get(loader.getProjectPath(), subPath).toFile();
 

--- a/classifai-core/src/main/java/ai/classifai/action/parser/ProjectParser.java
+++ b/classifai-core/src/main/java/ai/classifai/action/parser/ProjectParser.java
@@ -91,7 +91,7 @@ public class ProjectParser
 
             JsonObject jsonObject = (JsonObject) item.getValue();
 
-            String subPath = String.join(File.separator,jsonObject.getString(ParamConfig.getImgPathParam()).split("(/|\\\\)"));
+            String subPath = String.join(File.separator,jsonObject.getString(ParamConfig.getImgPathParam()).split("[/\\\\]"));
 
             File fullPath = Paths.get(loader.getProjectPath(), subPath).toFile();
 

--- a/classifai-core/src/main/java/ai/classifai/data/type/image/BmpImageData.java
+++ b/classifai-core/src/main/java/ai/classifai/data/type/image/BmpImageData.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020-2021 CertifAI Sdn. Bhd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.classifai.data.type.image;
+
+import com.drew.metadata.Metadata;
+import com.drew.metadata.MetadataException;
+import com.drew.metadata.bmp.BmpHeaderDirectory;
+
+/**
+ * Provides metadata of bmp images
+ *
+ * @author YCCertifai
+ */
+public class BmpImageData extends ImageData
+{
+    public BmpImageData(Metadata metadata)
+    {
+        super(metadata);
+    }
+
+    @Override
+    public int getWidth() throws MetadataException
+    {
+        return metadata.getFirstDirectoryOfType(BmpHeaderDirectory.class).getInt(BmpHeaderDirectory.TAG_IMAGE_WIDTH);
+    }
+
+    @Override
+    public int getHeight() throws MetadataException
+    {
+        return metadata.getFirstDirectoryOfType(BmpHeaderDirectory.class).getInt(BmpHeaderDirectory.TAG_IMAGE_HEIGHT);
+    }
+}

--- a/classifai-core/src/main/java/ai/classifai/data/type/image/ImageData.java
+++ b/classifai-core/src/main/java/ai/classifai/data/type/image/ImageData.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020-2021 CertifAI Sdn. Bhd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.classifai.data.type.image;
+
+import com.drew.metadata.Metadata;
+import com.drew.metadata.MetadataException;
+
+/**
+ * ImageData provides metadata of images
+ *
+ * @author YCCertifai
+ */
+public abstract class ImageData
+{
+    protected Metadata metadata;
+
+    protected ImageData(Metadata metadata)
+    {
+        this.metadata = metadata;
+    }
+
+    public abstract int getWidth() throws MetadataException;
+    public abstract int getHeight() throws MetadataException;
+}

--- a/classifai-core/src/main/java/ai/classifai/data/type/image/ImageDataFactory.java
+++ b/classifai-core/src/main/java/ai/classifai/data/type/image/ImageDataFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020-2021 CertifAI Sdn. Bhd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.classifai.data.type.image;
+
+import ai.classifai.util.exception.NotSupportedImageTypeException;
+import com.drew.metadata.Metadata;
+import com.drew.metadata.bmp.BmpHeaderDirectory;
+import com.drew.metadata.jpeg.JpegDirectory;
+import com.drew.metadata.png.PngDirectory;
+
+/**
+ * ImageDataFactory to return subclass of ImageData based on metadata
+ * throw NotSupportedImageTypeError if image type is not supported
+ *
+ * @author YCCertifai
+ */
+public class ImageDataFactory
+{
+    public ImageData getImageData(Metadata metadata) throws NotSupportedImageTypeException
+    {
+        if (metadata.containsDirectoryOfType(JpegDirectory.class))
+        {
+            return new JpegImageData(metadata);
+        }
+        else if (metadata.containsDirectoryOfType(PngDirectory.class))
+        {
+            return new PngImageData(metadata);
+        }
+        else if (metadata.containsDirectoryOfType(BmpHeaderDirectory.class))
+        {
+            return new BmpImageData(metadata);
+        }
+        else
+        {
+            throw new NotSupportedImageTypeException("File type not supported");
+        }
+    }
+}

--- a/classifai-core/src/main/java/ai/classifai/data/type/image/JpegImageData.java
+++ b/classifai-core/src/main/java/ai/classifai/data/type/image/JpegImageData.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020-2021 CertifAI Sdn. Bhd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.classifai.data.type.image;
+
+import com.drew.metadata.Metadata;
+import com.drew.metadata.MetadataException;
+import com.drew.metadata.jpeg.JpegDirectory;
+
+/**
+ * Provides metadata of jpeg images
+ *
+ * @author YCCertifai
+ */
+public class JpegImageData extends ImageData
+{
+    public JpegImageData(Metadata metadata)
+    {
+        super(metadata);
+    }
+
+    @Override
+    public int getWidth() throws MetadataException {
+        return metadata.getFirstDirectoryOfType(JpegDirectory.class).getInt(JpegDirectory.TAG_IMAGE_WIDTH);
+    }
+
+    @Override
+    public int getHeight() throws MetadataException {
+        return metadata.getFirstDirectoryOfType(JpegDirectory.class).getInt(JpegDirectory.TAG_IMAGE_HEIGHT);
+    }
+}

--- a/classifai-core/src/main/java/ai/classifai/data/type/image/PngImageData.java
+++ b/classifai-core/src/main/java/ai/classifai/data/type/image/PngImageData.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020-2021 CertifAI Sdn. Bhd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.classifai.data.type.image;
+
+import com.drew.metadata.Metadata;
+import com.drew.metadata.MetadataException;
+import com.drew.metadata.png.PngDirectory;
+
+/**
+ * Provides metadata of png images
+ *
+ * @author YCCertifai
+ */
+public class PngImageData extends ImageData
+{
+    public PngImageData(Metadata metadata)
+    {
+        super(metadata);
+    }
+
+    @Override
+    public int getWidth() throws MetadataException
+    {
+        return metadata.getFirstDirectoryOfType(PngDirectory.class).getInt(PngDirectory.TAG_IMAGE_WIDTH);
+    }
+
+    @Override
+    public int getHeight() throws MetadataException
+    {
+        return metadata.getFirstDirectoryOfType(PngDirectory.class).getInt(PngDirectory.TAG_IMAGE_HEIGHT);
+    }
+}

--- a/classifai-core/src/main/java/ai/classifai/database/annotation/AnnotationVerticle.java
+++ b/classifai-core/src/main/java/ai/classifai/database/annotation/AnnotationVerticle.java
@@ -401,7 +401,7 @@ public abstract class AnnotationVerticle extends AbstractVerticle implements Ver
     {
         String projectId = loader.getProjectId();
 
-        String dataChildPath = StringHandler.removeSlashes(FileHandler.trimPath(loader.getProjectPath(), dataFullPath.getAbsolutePath()));
+        String dataChildPath = StringHandler.removeFirstSlashes(FileHandler.trimPath(loader.getProjectPath(), dataFullPath.getAbsolutePath()));
 
         Tuple params = Tuple.of(dataChildPath, projectId);
 

--- a/classifai-core/src/main/java/ai/classifai/router/EndpointRouter.java
+++ b/classifai-core/src/main/java/ai/classifai/router/EndpointRouter.java
@@ -21,8 +21,10 @@ import ai.classifai.selector.project.ProjectFolderSelector;
 import ai.classifai.selector.project.ProjectImportSelector;
 import ai.classifai.util.ParamConfig;
 import io.vertx.core.AbstractVerticle;
+import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
 import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.StaticHandler;
 import lombok.extern.slf4j.Slf4j;
 
@@ -79,12 +81,20 @@ public class EndpointRouter extends AbstractVerticle
         cloud.setVertx(vertx);
     }
 
+    private void addNoCacheHeader(RoutingContext ctx)
+    {
+        ctx.response().headers().add("Cache-Control", "no-cache");
+        ctx.next();
+    }
+
     @Override
     public void start(Promise<Void> promise)
     {
         Router router = Router.router(vertx);
 
         //display for content in webroot
+        //uses no-cache header for cache busting, perform revalidation when fetching static assets
+        router.route().handler(this::addNoCacheHeader);
         router.route().handler(StaticHandler.create());
 
         final String projectEndpoint = "/:annotation_type/projects/:project_name";

--- a/classifai-core/src/main/java/ai/classifai/router/EndpointRouter.java
+++ b/classifai-core/src/main/java/ai/classifai/router/EndpointRouter.java
@@ -21,7 +21,6 @@ import ai.classifai.selector.project.ProjectFolderSelector;
 import ai.classifai.selector.project.ProjectImportSelector;
 import ai.classifai.util.ParamConfig;
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;

--- a/classifai-core/src/main/java/ai/classifai/util/data/ImageHandler.java
+++ b/classifai-core/src/main/java/ai/classifai/util/data/ImageHandler.java
@@ -15,12 +15,15 @@
  */
 package ai.classifai.util.data;
 
+import ai.classifai.data.type.image.ImageData;
+import ai.classifai.data.type.image.ImageDataFactory;
 import ai.classifai.data.type.image.ImageFileType;
 import ai.classifai.database.annotation.AnnotationVerticle;
 import ai.classifai.loader.ProjectLoader;
 import ai.classifai.selector.filesystem.FileSystemStatus;
 import ai.classifai.util.ParamConfig;
 import ai.classifai.util.project.ProjectHandler;
+import com.drew.imaging.ImageMetadataReader;
 import com.drew.imaging.jpeg.JpegMetadataReader;
 import com.drew.metadata.Directory;
 import com.drew.metadata.Metadata;
@@ -250,24 +253,19 @@ public class ImageHandler {
     {
         try
         {
-            File filePath = new File(file);
+            Metadata metadata = ImageMetadataReader.readMetadata(new File(file));
 
-            BufferedImage bimg = ImageIO.read(filePath);
+            ImageData imgData = new ImageDataFactory().getImageData(metadata);
 
-            if (bimg == null)
+            if (imgData.getWidth() > ImageFileType.getMaxWidth() || imgData.getHeight() > ImageFileType.getMaxHeight())
             {
-                log.info("Failed in reading. Skipped " + filePath.getAbsolutePath());
-                return false;
-            }
-            else if ((bimg.getWidth() > ImageFileType.getMaxWidth()) || (bimg.getHeight() > ImageFileType.getMaxHeight()))
-            {
-                log.info("Image size bigger than maximum allowed input size. Skipped " + filePath.getAbsolutePath());
+                log.info("Image size bigger than maximum allowed input size. Skipped " + file);
                 return false;
             }
         }
         catch (Exception e)
         {
-            log.debug("Error in checking if image file valid - " + file, e);
+            log.info("Skipped " + file, e);
             return false;
         }
 

--- a/classifai-core/src/main/java/ai/classifai/util/data/ImageHandler.java
+++ b/classifai-core/src/main/java/ai/classifai/util/data/ImageHandler.java
@@ -322,7 +322,7 @@ public class ImageHandler {
         {
             for (int i = 0; i < filesPath.size(); ++i)
             {
-                String dataSubPath = Paths.get(((File) filesPath.get(i)).getAbsolutePath()).getFileName().toString();
+                String dataSubPath = StringHandler.removeFirstSlashes(FileHandler.trimPath(loader.getProjectPath(), ((File) filesPath.get(i)).getAbsolutePath()));
 
                 AnnotationVerticle.saveDataPoint(loader, dataSubPath, i + 1);
             }

--- a/classifai-core/src/main/java/ai/classifai/util/data/StringHandler.java
+++ b/classifai-core/src/main/java/ai/classifai/util/data/StringHandler.java
@@ -28,4 +28,9 @@ public class StringHandler
     {
         return input.replace("\\", "").replace("/", "");
     }
+
+    public static String removeFirstSlashes(@NonNull String input)
+    {
+        return removeSlashes(input.substring(0,2)) + input.substring(2);
+    }
 }

--- a/classifai-core/src/main/java/ai/classifai/util/exception/NotSupportedImageTypeException.java
+++ b/classifai-core/src/main/java/ai/classifai/util/exception/NotSupportedImageTypeException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020-2021 CertifAI Sdn. Bhd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.classifai.util.exception;
+
+/**
+ * Exception thrown when data type is not supported
+ *
+ * @author YCCertifai
+ */
+public class NotSupportedImageTypeException extends Exception{
+
+    public NotSupportedImageTypeException(String message)
+    {
+        super(message);
+    }
+}


### PR DESCRIPTION
# Description

### Cache Busting
Same logic as #312

### Image Validation Time Improvement
Same logic as #339 with changes made as per request by @codenamewei 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tested on?

- [ ] Windows  
- [x] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged