### PR TITLE
Fix duplicate image when reload

### DIFF
--- a/classifai-core/src/main/java/ai/classifai/action/parser/ProjectParser.java
+++ b/classifai-core/src/main/java/ai/classifai/action/parser/ProjectParser.java
@@ -22,6 +22,7 @@ import ai.classifai.database.versioning.AnnotationVersion;
 import ai.classifai.loader.ProjectLoader;
 import ai.classifai.util.Hash;
 import ai.classifai.util.ParamConfig;
+import ai.classifai.util.data.StringHandler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowIterator;
@@ -54,7 +55,7 @@ public class ProjectParser
         {
             Row row = rowIterator.next();
 
-            String imgPath = row.getString(1).replace("\\", "").replace("/", "");
+            String imgPath = StringHandler.removeSlashes(row.getString(1));
 
             String fullPath = Paths.get(projectPath, imgPath).toString();
 

--- a/classifai-core/src/main/java/ai/classifai/database/annotation/AnnotationVerticle.java
+++ b/classifai-core/src/main/java/ai/classifai/database/annotation/AnnotationVerticle.java
@@ -414,7 +414,6 @@ public abstract class AnnotationVerticle extends AbstractVerticle implements Ver
                     //not exist , create data point
                     if (rowSet.size() == 0)
                     {
-                        log.info("Image not exist in database");
                         if(ImageHandler.isImageReadable(dataFullPath))
                         {
                             writeUuidToDbFromReloadingRootPath(loader, dataChildPath);

--- a/classifai-core/src/main/java/ai/classifai/database/annotation/AnnotationVerticle.java
+++ b/classifai-core/src/main/java/ai/classifai/database/annotation/AnnotationVerticle.java
@@ -26,6 +26,7 @@ import ai.classifai.util.collection.ConversionHandler;
 import ai.classifai.util.collection.UuidGenerator;
 import ai.classifai.util.data.FileHandler;
 import ai.classifai.util.data.ImageHandler;
+import ai.classifai.util.data.StringHandler;
 import ai.classifai.util.message.ReplyHandler;
 import ai.classifai.util.project.ProjectHandler;
 import ai.classifai.util.type.AnnotationHandler;
@@ -327,8 +328,6 @@ public abstract class AnnotationVerticle extends AbstractVerticle implements Ver
                                 }
 
                             }
-
-
                         }
                     }
                 });
@@ -400,7 +399,7 @@ public abstract class AnnotationVerticle extends AbstractVerticle implements Ver
     {
         String projectId = loader.getProjectId();
 
-        String dataChildPath = FileHandler.trimPath(loader.getProjectPath(), dataFullPath.getAbsolutePath());
+        String dataChildPath = StringHandler.removeSlashes(FileHandler.trimPath(loader.getProjectPath(), dataFullPath.getAbsolutePath()));
 
         Tuple params = Tuple.of(dataChildPath, projectId);
 
@@ -415,7 +414,7 @@ public abstract class AnnotationVerticle extends AbstractVerticle implements Ver
                     //not exist , create data point
                     if (rowSet.size() == 0)
                     {
-
+                        log.info("Image not exist in database");
                         if(ImageHandler.isImageReadable(dataFullPath))
                         {
                             writeUuidToDbFromReloadingRootPath(loader, dataChildPath);

--- a/classifai-core/src/main/java/ai/classifai/database/portfolio/PortfolioVerticle.java
+++ b/classifai-core/src/main/java/ai/classifai/database/portfolio/PortfolioVerticle.java
@@ -477,6 +477,7 @@ public class PortfolioVerticle extends AbstractVerticle implements VerticleServi
                                 Version currentVersion = new Version(row.getString(7));
 
                                 ProjectVersion project = PortfolioParser.loadProjectVersion(row.getString(8));     //project_version
+
                                 project.setCurrentVersion(currentVersion.getVersionUuid());
 
                                 Map uuidDict = ActionOps.getKeyWithArray(row.getString(9));
@@ -499,7 +500,6 @@ public class PortfolioVerticle extends AbstractVerticle implements VerticleServi
 
                                 //load each data points
                                 AnnotationVerticle.configProjectLoaderFromDb(loader);
-
                                 ProjectHandler.loadProjectLoader(loader);
                             }
                         }

--- a/classifai-core/src/main/java/ai/classifai/selector/project/ProjectFolderSelector.java
+++ b/classifai-core/src/main/java/ai/classifai/selector/project/ProjectFolderSelector.java
@@ -138,7 +138,7 @@ public class ProjectFolderSelector extends SelectionWindow {
         return null;
     }
 
-    public static void initFolderIteration(@NonNull ProjectLoader loader) throws IOException {
+    public void initFolderIteration(@NonNull ProjectLoader loader) throws IOException {
         loader.setFileSystemStatus(FileSystemStatus.WINDOW_CLOSE_LOADING_FILES);
 
         String projectPath = loader.getProjectPath();

--- a/classifai-core/src/main/java/ai/classifai/selector/project/ProjectFolderSelector.java
+++ b/classifai-core/src/main/java/ai/classifai/selector/project/ProjectFolderSelector.java
@@ -138,7 +138,7 @@ public class ProjectFolderSelector extends SelectionWindow {
         return null;
     }
 
-    private void initFolderIteration(@NonNull ProjectLoader loader) throws IOException {
+    public static void initFolderIteration(@NonNull ProjectLoader loader) throws IOException {
         loader.setFileSystemStatus(FileSystemStatus.WINDOW_CLOSE_LOADING_FILES);
 
         String projectPath = loader.getProjectPath();

--- a/classifai-core/src/main/java/ai/classifai/util/data/StringHandler.java
+++ b/classifai-core/src/main/java/ai/classifai/util/data/StringHandler.java
@@ -15,36 +15,17 @@
  */
 package ai.classifai.util.data;
 
-import com.drew.lang.annotations.Nullable;
 import lombok.NonNull;
-
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * String processing operation
  *
  * @author codenamewei
  */
-@Deprecated
 public class StringHandler
 {
-    private static String replacement = "";
-
-    public static String cleanUpRegex(@NonNull String input)
+    public static String removeSlashes(@NonNull String input)
     {
-        return cleanUpRegex(input, Arrays.asList("\""));
-    }
-
-    public static String cleanUpRegex(@NonNull String input, @Nullable List<String> regexList)
-    {
-        String output = input;
-
-        for(String regex : regexList)
-        {
-            output = output.replace(regex, replacement);
-        }
-
-        return output;
+        return input.replace("\\", "").replace("/", "");
     }
 }


### PR DESCRIPTION
# Description

When using reload on project that is created using import, image will be duplicated. 

Change:

- When importing from config file, remove slashes before saving to db.
- Also standardize the remove slash function

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tested on?

- [X] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged