### PR TITLE
Fix thread blocking when export with big data

### DIFF
--- a/classifai-core/src/main/java/ai/classifai/action/FileGenerator.java
+++ b/classifai-core/src/main/java/ai/classifai/action/FileGenerator.java
@@ -41,11 +41,11 @@ public class FileGenerator {
                 log.info("Exporting project config with data");
                 try
                 {
-                    exportPath = ProjectExport.exportToFileWithData(message, loader, loader.getProjectId(), configContent);
+                    exportPath = ProjectExport.exportToFileWithData(loader, loader.getProjectId(), configContent);
                 }
                 catch (IOException e)
                 {
-                    e.printStackTrace();
+                    log.info("Exporting fail");
                 }
             }
             else if (exportType == ActionConfig.ExportType.CONFIG_ONLY.ordinal())

--- a/classifai-core/src/main/java/ai/classifai/action/FileGenerator.java
+++ b/classifai-core/src/main/java/ai/classifai/action/FileGenerator.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021 CertifAI Sdn. Bhd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package ai.classifai.action;
+
+import ai.classifai.loader.ProjectLoader;
+import ai.classifai.util.message.ReplyHandler;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonObject;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+import java.awt.*;
+import java.io.IOException;
+
+/**
+ * Creating files for export function
+ *
+ * @author devenyantis
+ */
+@Slf4j
+public class FileGenerator {
+
+    public void run(Message<JsonObject> message, @NonNull ProjectLoader loader, @NonNull JsonObject configContent, @NonNull int exportType) {
+        EventQueue.invokeLater(() -> {
+            String exportPath = null;
+            if(exportType == ActionConfig.ExportType.CONFIG_WITH_DATA.ordinal())
+            {
+                log.info("Exporting project config with data");
+                try
+                {
+                    exportPath = ProjectExport.exportToFileWithData(message, loader, loader.getProjectId(), configContent);
+                }
+                catch (IOException e)
+                {
+                    e.printStackTrace();
+                }
+            }
+            else if (exportType == ActionConfig.ExportType.CONFIG_ONLY.ordinal())
+            {
+                log.info("Exporting project config");
+                exportPath = ProjectExport.exportToFile(loader.getProjectId(), configContent);
+            }
+
+            if(exportPath != null)
+            {
+                message.reply(ReplyHandler.getOkReply().put(
+                        ActionConfig.getProjectConfigPathParam(), exportPath));
+
+                return;
+            }
+            message.reply(ReplyHandler.getFailedReply());
+        });
+    }
+}

--- a/classifai-core/src/main/java/ai/classifai/action/ProjectExport.java
+++ b/classifai-core/src/main/java/ai/classifai/action/ProjectExport.java
@@ -81,7 +81,7 @@ public class ProjectExport
         return configPath;
     }
 
-    public static String exportToFileWithData(Message<JsonObject> message, ProjectLoader loader, String projectId, JsonObject configContent) throws IOException
+    public static String exportToFileWithData(ProjectLoader loader, String projectId, JsonObject configContent) throws IOException
     {
         String configPath = exportToFile(projectId, configContent);
         File zipFile = Paths.get(loader.getProjectPath(), loader.getProjectName() + ".zip").toFile();

--- a/classifai-core/src/main/java/ai/classifai/action/ProjectExport.java
+++ b/classifai-core/src/main/java/ai/classifai/action/ProjectExport.java
@@ -22,7 +22,6 @@ import ai.classifai.util.ParamConfig;
 import ai.classifai.util.data.ImageHandler;
 import ai.classifai.util.datetime.DateTime;
 import ai.classifai.util.project.ProjectHandler;
-import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonObject;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;

--- a/classifai-core/src/main/java/ai/classifai/database/portfolio/PortfolioVerticle.java
+++ b/classifai-core/src/main/java/ai/classifai/database/portfolio/PortfolioVerticle.java
@@ -18,6 +18,7 @@ package ai.classifai.database.portfolio;
 import ai.classifai.action.ActionConfig;
 import ai.classifai.action.ActionOps;
 import ai.classifai.action.ProjectExport;
+import ai.classifai.action.FileGenerator;
 import ai.classifai.action.parser.PortfolioParser;
 import ai.classifai.action.parser.ProjectParser;
 import ai.classifai.database.DbConfig;
@@ -71,6 +72,7 @@ import java.util.*;
 public class PortfolioVerticle extends AbstractVerticle implements VerticleServiceable, PortfolioServiceable
 {
     @Setter private static JDBCPool portfolioDbPool;
+    @Setter private static FileGenerator fileGenerator;
 
     public void onMessage(Message<JsonObject> message)
     {
@@ -373,15 +375,7 @@ public class PortfolioVerticle extends AbstractVerticle implements VerticleServi
 
         int exportType = message.body().getInteger(ActionConfig.getExportTypeParam());
 
-        String exportPath = ProjectExport.runExportProcess(loader, configContent, exportType);
-        if(exportPath != null)
-        {
-            message.reply(ReplyHandler.getOkReply().put(
-                    ActionConfig.getProjectConfigPathParam(), exportPath));
-
-            return;
-        }
-        message.reply(ReplyHandler.getFailedReply());
+        fileGenerator.run(message, loader, configContent, exportType);
     }
 
 

--- a/classifai-core/src/main/java/ai/classifai/router/EndpointRouter.java
+++ b/classifai-core/src/main/java/ai/classifai/router/EndpointRouter.java
@@ -15,6 +15,8 @@
  */
 package ai.classifai.router;
 
+import ai.classifai.action.FileGenerator;
+import ai.classifai.database.portfolio.PortfolioVerticle;
 import ai.classifai.selector.annotation.ToolFileSelector;
 import ai.classifai.selector.annotation.ToolFolderSelector;
 import ai.classifai.selector.project.LabelListSelector;
@@ -41,6 +43,8 @@ public class EndpointRouter extends AbstractVerticle
     private ProjectFolderSelector projectFolderSelector;
     private ProjectImportSelector projectImporter;
     private LabelListSelector labelListSelector;
+    private FileGenerator fileGenerator;
+
 
     V1Endpoint v1 = new V1Endpoint();
     V2Endpoint v2 = new V2Endpoint();
@@ -63,6 +67,9 @@ public class EndpointRouter extends AbstractVerticle
 
         Thread labelListImport = new Thread(() -> labelListSelector = new LabelListSelector());
         labelListImport.start();
+
+        Thread threadZipFileGenerator = new Thread(() -> fileGenerator = new FileGenerator());
+        threadZipFileGenerator.start();
     }
 
     @Override
@@ -85,6 +92,8 @@ public class EndpointRouter extends AbstractVerticle
         v2.setLabelListSelector(labelListSelector);
 
         cloud.setVertx(vertx);
+
+        PortfolioVerticle.setFileGenerator(fileGenerator);
     }
 
     private void addNoCacheHeader(RoutingContext ctx)


### PR DESCRIPTION
# Description

Main issue is when event require lots of time to perform process in the event bus triggering thread blocking exception. In my test, process return value to frontend is non deterministic. 

**What change**
The main idea is to detach the process from event bus by spawning thread only when processing zip file. 

Vertx community did not encourage to use independent thread. Thus, the process that use thread is only when writing to zip file. Also send the reply message back to frontend. Minimal change made.

This fix is only temporary so that undefined behavior cause by thread blocking does not effect the overall functionality. I think letting the eventbus run normally is more important rather than running with the problem.

Tested on 500 and 1k images. 

Fixes #362 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tested on?

- [X] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged