### PR TITLE
Readme update

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,13 +12,13 @@
     <a href="https://github.com/CertifaiAI/classifai/releases">
         <img alt="GitHub release" src="https://img.shields.io/github/release/CertifaiAI/classifai.svg?color=yellow">
     </a>
-    <a href="https://img.shields.io/sonar/quality_gate/CertifaiAI_classifai?server=https%3A%2F%2Fsonarcloud.io">
+    <a href="https://sonarcloud.io/dashboard?id=CertifaiAI_classifai">
         <img alt="Sonar Cloud Quality Gate" src="https://img.shields.io/sonar/quality_gate/CertifaiAI_classifai?server=https%3A%2F%2Fsonarcloud.io">
     </a>
     <a href="https://classifai.ai">
-        <img alt="Documentation" src="https://img.shields.io/website/http/certifai.ai.svg?color=orange">
+        <img alt="Website" src="https://img.shields.io/website/http/classifai.ai.svg?color=orange">
     </a>
-    <a href="Discord">
+    <a href="https://discord.gg/WsBFgNP">
         <img alt="Discord" src="https://img.shields.io/discord/699181979316387842?color=informational">
     </a>
 </p>

--- a/readme.md
+++ b/readme.md
@@ -27,8 +27,6 @@
 Data Annotation Platform for AI Training
 </h3>
 
-[![](https://sourcerer.io/fame/codenamewei/CertifaiAI/classifai/images/0)](https://sourcerer.io/fame/codenamewei/CertifaiAI/classifai/links/0)[![](https://sourcerer.io/fame/codenamewei/CertifaiAI/classifai/images/1)](https://sourcerer.io/fame/codenamewei/CertifaiAI/classifai/links/1)[![](https://sourcerer.io/fame/codenamewei/CertifaiAI/classifai/images/2)](https://sourcerer.io/fame/codenamewei/CertifaiAI/classifai/links/2)[![](https://sourcerer.io/fame/codenamewei/CertifaiAI/classifai/images/3)](https://sourcerer.io/fame/codenamewei/CertifaiAI/classifai/links/3)[![](https://sourcerer.io/fame/codenamewei/CertifaiAI/classifai/images/4)](https://sourcerer.io/fame/codenamewei/CertifaiAI/classifai/links/4)[![](https://sourcerer.io/fame/codenamewei/CertifaiAI/classifai/images/5)](https://sourcerer.io/fame/codenamewei/CertifaiAI/classifai/links/5)[![](https://sourcerer.io/fame/codenamewei/CertifaiAI/classifai/images/6)](https://sourcerer.io/fame/codenamewei/CertifaiAI/classifai/links/6)[![](https://sourcerer.io/fame/codenamewei/CertifaiAI/classifai/images/7)](https://sourcerer.io/fame/codenamewei/CertifaiAI/classifai/links/7)
-
 **Classifai** is one of the most comprehensive open-source data annotation platform.  
 It supports the labelling of various data types with multi labelled outputs forms for AI model training.  
 


### PR DESCRIPTION
# Description

Clicking on each thumbnail below should leads to website. 

However clicking on these 3 previously did not worked due to illy-constructed urls.
Checked out [v2_alpha](https://github.com/CertifaiAI/classifai/tree/v2_alpha) branch to reproduce the hiccup.

![Screenshot 2021-05-10 at 5 43 25 AM](https://user-images.githubusercontent.com/33477318/117588007-6338c980-b153-11eb-95cd-d87ffc6b8a44.png)



Fixed it in this PR. 


Desired behaviour/How to check:
Click on each thumbnail should lead to intended web page

# Tested on?

- [ ] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [x] Mac  
- [ ] Others  (State here -> xxx )  

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged