### PR TITLE
Adding automatic PR creation workflow

### DIFF
--- a/.github/workflows/auto_pr.yml
+++ b/.github/workflows/auto_pr.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           github_token: ${{ secrets.PERSONAL_TOKEN }}
           destination_branch: "v2_alpha" # Base Branch which changes will be applied to                     
-          pr_title: "Copying and pasting dist folder's contents from Classifai_FrontEnd to classifai's webroot" # Set title for the PR
+          pr_title: "[Test]Copying and pasting dist folder's contents from Classifai_FrontEnd to classifai's webroot" # Set title for the PR
           pr_body: | # PR's body
             ## This is an automatically created PR :robot::robot:
             
@@ -28,7 +28,7 @@ jobs:
             [2]: https://github.com/CertifaiAI/classifai/tree/v2_alpha/classifai-core/src/main/resources/webroot
             [3]: https://github.com/CertifaiAI/Classifai_FrontEnd/tree/main/dist/classifai
 
-          pr_reviewer: "fariskamaludin-skymind"  # Reviewer(s), can be Comma-separated list (no spaces)                                            
+          pr_reviewer: "codenamewei"  # Reviewer(s), can be Comma-separated list (no spaces)                                            
           pr_label: "auto-pr" # Set label for the PR                              
           pr_allow_empty: true # Creates pull request even if there are no changes
 

--- a/.github/workflows/auto_pr.yml
+++ b/.github/workflows/auto_pr.yml
@@ -2,7 +2,7 @@ name: Auto Create PR
 
 on:
   push:
-    branches: faris_auto_pr
+    branches: faris_auto_pr # Branch will be automatically created once automated copy workflow from Classifai_FrontEnd is triggered
 
 jobs:
   PR:
@@ -21,13 +21,16 @@ jobs:
           pr_body: | # PR's body
             ## This is an automatically created PR :robot::robot:
             
-            - It will triggered once codes in **dist folder** from repo [***Classifai_FrontEnd***][1] has been pushed.
-            - Files & sub-folder in **dist folder** of repo [***Classifai_FrontEnd***][1] will be copied into [***classifai's webroot***][2]
+            - It will triggered once codes in [***dist folder***][3] from repo [***Classifai_FrontEnd***][1] has been pushed.
+            - Files & sub-folder in [***dist folder***][3] of repo [***Classifai_FrontEnd***][1] will be copied into [***classifai's webroot***][2]
 
             [1]: https://github.com/CertifaiAI/Classifai_FrontEnd
             [2]: https://github.com/CertifaiAI/classifai/tree/v2_alpha/classifai-core/src/main/resources/webroot
+            [3]: https://github.com/CertifaiAI/Classifai_FrontEnd/tree/main/dist/classifai
 
           pr_reviewer: "fariskamaludin-skymind"  # Reviewer(s), can be Comma-separated list (no spaces)                                            
           pr_label: "auto-pr" # Set label for the PR                              
-          #pr_allow_empty: true
-          #pr_draft: true                             
+          pr_allow_empty: true # Creates pull request even if there are no changes
+
+          # Further reference from https://github.com/repo-sync/pull-request
+                             

--- a/.github/workflows/auto_pr.yml
+++ b/.github/workflows/auto_pr.yml
@@ -16,7 +16,7 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           github_token: ${{ secrets.PERSONAL_TOKEN }}
-          destination_branch: "main" # Base Branch which changes will be applied to                     
+          destination_branch: "v2_alpha" # Base Branch which changes will be applied to                     
           pr_title: "Copying and pasting dist folder's contents from Classifai_FrontEnd to classifai's webroot" # Set title for the PR
           pr_body: | # PR's body
             ## This is an automatically created PR :robot::robot:
@@ -28,6 +28,6 @@ jobs:
             [2]: https://github.com/CertifaiAI/classifai/tree/v2_alpha/classifai-core/src/main/resources/webroot
 
           pr_reviewer: "fariskamaludin-skymind"  # Reviewer(s), can be Comma-separated list (no spaces)                                            
-          pr_label: "auto-pr"                               
-          pr_allow_empty: true
+          pr_label: "auto-pr" # Set label for the PR                              
+          #pr_allow_empty: true
           #pr_draft: true                             

--- a/.github/workflows/auto_pr.yml
+++ b/.github/workflows/auto_pr.yml
@@ -1,0 +1,33 @@
+name: Auto Create PR
+
+on:
+  push:
+    branches: faris_auto_pr
+
+jobs:
+  PR:
+    name: Create PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repos
+        uses: actions/checkout@v2
+
+      - name: Create PR request
+        uses: repo-sync/pull-request@v2
+        with:
+          github_token: ${{ secrets.PERSONAL_TOKEN }}
+          destination_branch: "main" # Base Branch which changes will be applied to                     
+          pr_title: "Copying and pasting dist folder's contents from Classifai_FrontEnd to classifai's webroot" # Set title for the PR
+          pr_body: | # PR's body
+            ## This is an automatically created PR :robot::robot:
+            
+            - It will triggered once codes in **dist folder** from repo [***Classifai_FrontEnd***][1] has been pushed.
+            - Files & sub-folder in **dist folder** of repo [***Classifai_FrontEnd***][1] will be copied into [***classifai's webroot***][2]
+
+            [1]: https://github.com/CertifaiAI/Classifai_FrontEnd
+            [2]: https://github.com/CertifaiAI/classifai/tree/v2_alpha/classifai-core/src/main/resources/webroot
+
+          pr_reviewer: "fariskamaludin-skymind"  # Reviewer(s), can be Comma-separated list (no spaces)                                            
+          pr_label: "auto-pr"                               
+          pr_allow_empty: true
+          #pr_draft: true                             


### PR DESCRIPTION
# Description

- Adding automatic PR creation capability once copy paste [workflow][1] from Classifai_FrontEnd is triggered
- Adding this workflow will ease the process in syncing up between [dist folder][2] & [webroot folder][3]

[1]: https://github.com/CertifaiAI/Classifai_FrontEnd/blob/faris_added_copypaste_workflow/.github/workflows/copy.yml
[2]: https://github.com/CertifaiAI/Classifai_FrontEnd/tree/main/dist/classifai
[3]: https://github.com/CertifaiAI/classifai/tree/v2_alpha/classifai-core/src/main/resources/webroot

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Adding GitHub Action workflow

# Tested on?

- [ ] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [X] Mac  
- [ ] Others  (State here -> xxx )  

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged
- [ ] CHANGELOG.md has been updated.