### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,13 +10,13 @@
     <a href="https://github.com/CertifaiAI/classifai/releases">
         <img alt="GitHub release" src="https://img.shields.io/github/release/CertifaiAI/classifai.svg?color=yellow">
     </a>
-    <a href="https://img.shields.io/sonar/quality_gate/CertifaiAI_classifai?server=https%3A%2F%2Fsonarcloud.io">
+    <a href="https://sonarcloud.io/dashboard?id=CertifaiAI_classifai">
         <img alt="Sonar Cloud Quality Gate" src="https://img.shields.io/sonar/quality_gate/CertifaiAI_classifai?server=https%3A%2F%2Fsonarcloud.io">
     </a>
     <a href="https://classifai.ai">
         <img alt="Documentation" src="https://img.shields.io/website/http/certifai.ai.svg?color=orange">
     </a>
-    <a href="Discord">
+    <a href="https://discord.com/invite/WsBFgNP">
         <img alt="Discord" src="https://img.shields.io/discord/699181979316387842?color=informational">
     </a>
 </p>


### PR DESCRIPTION
# Description

Fix url forwarding of readme.md in v2_alpha

Intended behaviour:

Clicking on buttons illustrated as below (from readme.md) will leads to the content of corresponding text.

<img width="530" alt="Screenshot 2021-05-29 at 10 24 53 PM" src="https://user-images.githubusercontent.com/33477318/120073862-bb1c7d80-c0cc-11eb-91fc-31b5da78ce01.png">
