### PR TITLE
Fix label not saved for first project

### DIFF
--- a/classifai-core/src/main/java/ai/classifai/database/portfolio/PortfolioVerticle.java
+++ b/classifai-core/src/main/java/ai/classifai/database/portfolio/PortfolioVerticle.java
@@ -288,20 +288,9 @@ public class PortfolioVerticle extends AbstractVerticle implements VerticleServi
         JsonArray newLabelListJson = new JsonArray(message.body().getString(ParamConfig.getLabelListParam()));
 
         ProjectLoader loader = Objects.requireNonNull(ProjectHandler.getProjectLoader(projectId));
-
-        List<String> newLabelList = new ArrayList<>();
-
-        for(Object label: newLabelListJson)
-        {
-            String trimmedLabel = StringHandler.removeEndOfLineChar((String) label);
-
-            newLabelList.add(trimmedLabel);
-        }
-
         ProjectVersion project = loader.getProjectVersion();
 
-        project.setCurrentVersionLabelList(newLabelList);
-        loader.setLabelList(newLabelList);
+        updateLoaderLabelList(loader, project, newLabelListJson);
 
         Tuple updateUuidListBody = Tuple.of(project.getLabelVersionDbFormat(), projectId);
 
@@ -318,6 +307,22 @@ public class PortfolioVerticle extends AbstractVerticle implements VerticleServi
                         message.replyAndRequest(ReplyHandler.reportDatabaseQueryError(reply.cause()));
                     }
                 });
+    }
+
+
+    private void updateLoaderLabelList(ProjectLoader loader, ProjectVersion project, JsonArray newLabelListJson)
+    {
+        List<String> newLabelList = new ArrayList<>();
+
+        for(Object label: newLabelListJson)
+        {
+            String trimmedLabel = StringHandler.removeEndOfLineChar((String) label);
+
+            newLabelList.add(trimmedLabel);
+        }
+
+        project.setCurrentVersionLabelList(newLabelList);
+        loader.setLabelList(newLabelList);
     }
 
 

--- a/classifai-core/src/main/java/ai/classifai/router/V2Endpoint.java
+++ b/classifai-core/src/main/java/ai/classifai/router/V2Endpoint.java
@@ -147,7 +147,7 @@ public class V2Endpoint {
 
         String projectName = context.request().getParam(ParamConfig.getProjectNameParam());
 
-        projectFolderSelector.run(projectName, type);
+        projectFolderSelector.run(vertx, projectName, type);
 
         HTTPResponseHandler.configureOK(context);
     }

--- a/classifai-core/src/main/java/ai/classifai/selector/project/ProjectFolderSelector.java
+++ b/classifai-core/src/main/java/ai/classifai/selector/project/ProjectFolderSelector.java
@@ -16,7 +16,6 @@
 package ai.classifai.selector.project;
 
 import ai.classifai.database.portfolio.PortfolioDbQuery;
-import ai.classifai.database.portfolio.PortfolioVerticle;
 import ai.classifai.database.versioning.ProjectVersion;
 import ai.classifai.loader.LoaderStatus;
 import ai.classifai.loader.ProjectLoader;
@@ -26,20 +25,14 @@ import ai.classifai.ui.launcher.WelcomeLauncher;
 import ai.classifai.util.ParamConfig;
 import ai.classifai.util.collection.UuidGenerator;
 import ai.classifai.util.data.ImageHandler;
-import ai.classifai.util.http.HTTPResponseHandler;
-import ai.classifai.util.message.ReplyHandler;
 import ai.classifai.util.project.ProjectHandler;
 import ai.classifai.util.project.ProjectInfra;
 import ai.classifai.util.type.AnnotationHandler;
 import ai.classifai.util.type.AnnotationType;
-import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.json.JsonObject;
-import io.vertx.jdbcclient.JDBCPool;
-import io.vertx.sqlclient.Tuple;
 import lombok.NonNull;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 
@@ -48,7 +41,6 @@ import java.awt.*;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Locale;
 import java.util.Objects;
 

--- a/classifai-core/src/main/java/ai/classifai/selector/project/ProjectFolderSelector.java
+++ b/classifai-core/src/main/java/ai/classifai/selector/project/ProjectFolderSelector.java
@@ -88,7 +88,7 @@ public class ProjectFolderSelector extends SelectionWindow {
 
                     if(LabelListSelector.getLabelList() != null)
                     {
-                        saveAndClearLabelSelectorLabelList(vertx, loader);
+                        saveAndClearImportedLabels(vertx, loader);
                     }
 
                     log.debug("Proceed with creating project");
@@ -112,7 +112,7 @@ public class ProjectFolderSelector extends SelectionWindow {
         }
     }
 
-    private void saveAndClearLabelSelectorLabelList(Vertx vertx, ProjectLoader loader)
+    private void saveAndClearImportedLabels(Vertx vertx, ProjectLoader loader)
     {
         JsonObject jsonObject = new JsonObject();
         jsonObject.put(ParamConfig.getProjectIdParam(), loader.getProjectId());


### PR DESCRIPTION
# Description

The imported label list is not saved to database. So, the fix is to directly add new query from projectfolderselector to save the imported labels.

**How to reproduce bug**
1. Delete database
2. Create new project with imported labels
3. Export project and check the labels. It is empty. It is supposed to list down all imported labels. Alternatively, can check the database using h2 console for the first project only.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tested on?

- [X] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged
- [ ] CHANGELOG.md has been updated.