### PR TITLE
🔧 Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,10 +8,10 @@ Fixes # (issue)
 
 Please delete options that are not relevant.
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
+- [ ] Bug fix (Non-breaking change which fixes an issue)
+- [ ] New feature (Non-breaking change which adds functionality)
+- [ ] Breaking change (Fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update (Example: REST API changes)
 
 # Tested on?
 
@@ -31,4 +31,5 @@ Please delete options that are not relevant.
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged
-- [ ] CHANGELOG.md has been updated.
+- [ ] CHANGELOG.md has been updated
+- [ ] Update [Gitbook REST API Page](https://docs.classifai.ai/v/dev/development/rest-api)


### PR DESCRIPTION
# Description

Update PR template to include API documentation when applies

@devenyantis @YCCertifai 

I've put into PR template where when API changes happen and merge to main branch (in this case v2_alpha), the developer should take the liberty to update the reference api documentation too.

For contributor who don't have access, they will reach [the page](https://docs.classifai.ai/v/dev/development/rest-api) where they can choose to talk to us on how to update either using discord / email. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tested on?

- [ ] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged
- [ ] CHANGELOG.md has been updated.