### PR TITLE
Included Frontend's PR title in auto_pr title

### DIFF
--- a/.github/workflows/auto_pr.yml
+++ b/.github/workflows/auto_pr.yml
@@ -12,12 +12,20 @@ jobs:
       - name: Checkout Repos
         uses: actions/checkout@v2
 
+      - name: Pre-processing PR title
+        id: string
+        run: |
+          STRING="${{ github.event.head_commit.message }}"
+          STRING="${STRING/:lipstick: Compiled codes from https:\/\/github.com\//https:\/\/api.github.com\/repos\/}"
+          STRING="${STRING/pull/pulls}"
+          echo "::set-output name=pr_title::$(curl -H "Accept: application/vnd.github.v3+json" ${STRING} 2>/dev/null | jq -r ".title")"    
+
       - name: Create PR request
         uses: repo-sync/pull-request@v2
         with:
           github_token: ${{ secrets.PERSONAL_TOKEN }}
           destination_branch: "v2_alpha" # Base Branch which changes will be applied to                     
-          pr_title: "Copying and pasting dist folder's contents from Classifai_FrontEnd to classifai's webroot" # Set title for the PR
+          pr_title: "From classifai_frontend to classifai's webroot - ${{ steps.string.outputs.pr_title }}" # Set title for the PR
           pr_body: | # PR's body
             ## This is an automatically created PR :robot::robot:
             


### PR DESCRIPTION
# Description

- Included merged Frontend PR's title into auto_pr title
- Example as below:

![image](https://user-images.githubusercontent.com/83570177/128277664-cc4ca0be-4333-49a0-b4f7-4724b4dc58f2.png)

FYI, since one branch can only have one PR at a time, there will be a case where multiple merged frontend's PR will be stacked in the auto_pr. Only the oldest frontend's PR will be set as the title of auto_pr.

![image](https://user-images.githubusercontent.com/83570177/128278012-f16ff1d8-fb83-4187-a42d-f213ca186f4e.png)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [ ] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Example: REST API changes)
- [X] Adding/Updating CI workflow of GitHub Actions

# Tested on?

- [ ] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [X] Mac  
- [ ] Others  (State here -> xxx )  

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged
- [ ] CHANGELOG.md has been updated
- [ ] Update [Gitbook REST API Page](https://docs.classifai.ai/v/dev/development/rest-api)
