### PR TITLE
🎇 API to terminate classifai

### DIFF
--- a/classifai-core/src/main/java/ai/classifai/router/EndpointRouter.java
+++ b/classifai-core/src/main/java/ai/classifai/router/EndpointRouter.java
@@ -159,6 +159,8 @@ public class EndpointRouter extends AbstractVerticle
 
         router.delete("/v2/:annotation_type/projects/:project_name/uuids").handler(v2::deleteProjectData);
 
+        router.put("/v2/close").handler(v2::closeClassifai);
+
         //*******************************Cloud*******************************
 
         router.put("/v2/:annotation_type/wasabi/projects/:project_name").handler(cloud::createWasabiCloudProject);

--- a/classifai-core/src/main/java/ai/classifai/router/V2Endpoint.java
+++ b/classifai-core/src/main/java/ai/classifai/router/V2Endpoint.java
@@ -48,6 +48,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Classifai v2 endpoints
@@ -558,6 +559,29 @@ public class V2Endpoint extends EndpointBase {
 
         }
         HTTPResponseHandler.configureOK(context);
+    }
+
+    /**
+     * Close/terminate classifai
+     * PUT http://localhost:{port}/v2/close
+     *
+     * Example:
+     * PUT http://localhost:{port}/v2/close
+     */
+    public void closeClassifai(RoutingContext context)
+    {
+        HTTPResponseHandler.configureOK(context);
+
+        //terminate after 1 seconds
+        new java.util.Timer().schedule(
+                new java.util.TimerTask() {
+                    @Override
+                    public void run() {
+                        System.exit(0);
+                    }
+                },
+                1000
+        );
     }
 
     /**


### PR DESCRIPTION
# Description

As discussion, i crafted an API to close classifai with a pause of 1 second
```
PUT http://localhost:{port}/v2/close
```
Let me know if any changes needed thanks. 
For example do we need the pause to be longer, or no pause at all. from sending the response back to terminate the program. 

@devenyantis , this is to allow electron app to close backend when initiate from frontend 
rather than the way how its initiated from backend now.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (Non-breaking change which fixes an issue)
- [ ] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Example: REST API changes)

# Tested on?

- [ ] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged
- [ ] CHANGELOG.md has been updated
- [ ] Update [Gitbook REST API Page](https://docs.classifai.ai/v/dev/development/rest-api)
