### PR TITLE
♻️  Include properties according annotation type

### DIFF
--- a/classifai-core/src/main/java/ai/classifai/dto/data/AnnotationPointProperties.java
+++ b/classifai-core/src/main/java/ai/classifai/dto/data/AnnotationPointProperties.java
@@ -15,6 +15,7 @@
  */
 package ai.classifai.dto.data;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
@@ -27,18 +28,23 @@ import java.util.List;
 @NonNull
 public class AnnotationPointProperties {
     @JsonProperty
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     List<CoordinatesPointProperties> coorPt;
 
     @JsonProperty
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     Integer x1;
 
     @JsonProperty
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     Integer y1;
 
     @JsonProperty
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     Integer x2;
 
     @JsonProperty
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     Integer y2;
 
     @JsonProperty
@@ -48,12 +54,15 @@ public class AnnotationPointProperties {
     String color;
 
     @JsonProperty
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     String region;
 
     @JsonProperty
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     List<String> subLabel;
 
     @JsonProperty
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     DistanceToImageProperties distancetoImg;
 
     @JsonProperty


### PR DESCRIPTION
# Description

Making properties created according to bounding box and segmentation type. Because the project JSON file has included null properties that do not belong to the respective annotation type.

Fixes # [525](https://github.com/CertifaiAI/classifai/issues/525)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (Non-breaking change which fixes an issue)
- [ ] New feature (Non-breaking change which adds functionality)
- [ ] Breaking change (Fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Example: REST API changes)

# Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged
- [ ] CHANGELOG.md has been updated
- [ ] Update [Gitbook REST API Page](https://docs.classifai.ai/v/dev/development/rest-api)
